### PR TITLE
`npm` build subtasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "scripts": {
         "clean-wp": "rm -rf distribution/narrafirma.zip distribution/narrafirma",
         "build-wp:webapp": "cp -r webapp wordpress-plugin/narrafirma/* distribution/narrafirma",
-        "build-wp": "npm run clean-wp && mkdir distribution/narrafirma && tsc && npm run build-wp:webapp && cd distribution && node ../node_modules/requirejs/bin/r.js -o build-survey.js && node ../node_modules/requirejs/bin/r.js -o build-admin.js && node ../node_modules/requirejs/bin/r.js -o build-narrafirma.js && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd .. && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
+        "build-wp:optimize:survey": "node node_modules/requirejs/bin/r.js -o distribution/build-survey.js",
+        "build-wp:optimize:admin": "node node_modules/requirejs/bin/r.js -o distribution/build-admin.js",
+        "build-wp:optimize:narrafirma": "node node_modules/requirejs/bin/r.js -o distribution/build-narrafirma.js",
+        "build-wp": "npm run clean-wp && mkdir distribution/narrafirma && tsc && npm run build-wp:webapp && npm run build-wp:optimize:survey && npm run build-wp:optimize:admin && npm run build-wp:optimize:narrafirma && cd distribution && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd .. && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
      }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "main": "src",
     "homepage": "http://workingwithstories.com/",
     "scripts": {
-        "build-wp": "rm -rf distribution/narrafirma.zip && rm -rf distribution/narrafirma && mkdir distribution/narrafirma && tsc && cp -r webapp wordpress-plugin/narrafirma/* distribution/narrafirma && cd distribution && node ../node_modules/requirejs/bin/r.js -o build-survey.js && node ../node_modules/requirejs/bin/r.js -o build-admin.js && node ../node_modules/requirejs/bin/r.js -o build-narrafirma.js && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd .. && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
+        "clean-wp": "rm -rf distribution/narrafirma.zip distribution/narrafirma",
+        "build-wp:webapp": "cp -r webapp wordpress-plugin/narrafirma/* distribution/narrafirma",
+        "build-wp": "npm run clean-wp && mkdir distribution/narrafirma && tsc && npm run build-wp:webapp && cd distribution && node ../node_modules/requirejs/bin/r.js -o build-survey.js && node ../node_modules/requirejs/bin/r.js -o build-admin.js && node ../node_modules/requirejs/bin/r.js -o build-narrafirma.js && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd .. && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
      }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "build-wp:optimize:survey": "node node_modules/requirejs/bin/r.js -o distribution/build-survey.js",
         "build-wp:optimize:admin": "node node_modules/requirejs/bin/r.js -o distribution/build-admin.js",
         "build-wp:optimize:narrafirma": "node node_modules/requirejs/bin/r.js -o distribution/build-narrafirma.js",
-        "build-wp": "npm run clean-wp && mkdir distribution/narrafirma && tsc && npm run build-wp:webapp && npm run build-wp:optimize:survey && npm run build-wp:optimize:admin && npm run build-wp:optimize:narrafirma && cd distribution && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd .. && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
+        "package-wp": "cd distribution && rm -rf narrafirma/webapp/js && zip -qr narrafirma.zip narrafirma/* && cd ..",
+        "build-wp": "npm run clean-wp && mkdir distribution/narrafirma && tsc && npm run build-wp:webapp && npm run build-wp:optimize:survey && npm run build-wp:optimize:admin && npm run build-wp:optimize:narrafirma && npm run package-wp && rm -rf distribution/narrafirma && echo Done building NarraFirma WordPress plugin"
      }
 }


### PR DESCRIPTION
Per @pdfernhout:

> The npm build process is still rougher than it has to be though. For example, we should ideally break up the long npm run task for building the WordPress module into subtasks rather than have one long line.

I took a first pass at creating subtasks for the `npm` build process. We still have a really long line at the end, but this may at least provide a safe base for future changes.

To validate these changes, I compared two resulting zip files (one from a build without subtasks, another from a build with the subtasks) with a recursive diff.

There is one "gotcha" with respect to changing the working directory. I adjusted the `require.js` optimize process to operate without changing directories and isolated the directory change to the `package-wp` step. There might be a flag we can pass to `zip` that enables us to avoid the `cd` altogether, but since we can't reliably say that a given build environment has a particular `zip` binary installed, I'm less inclined to pursue it just yet.

I also left a few non-task commands in the final `build-wp` one-liner, because I wasn't comfortable categorizing or moving them yet. We may be able to abstract away and further group tasks to reduce the size of any given line, but for now this seems a solid start.
