### PR TITLE
fix: in mannWhitneyU, use T as is, not the sqrt

### DIFF
--- a/webapp/source/statistics/mannWhitneyU.ts
+++ b/webapp/source/statistics/mannWhitneyU.ts
@@ -32,7 +32,7 @@ function mannWhitneyU(x: number[], y: number[]) {
     var smallu = Math.min(u1, u2);
     
     // correction factor for tied scores
-    var T = Math.sqrt(tiecorrect(ranked));
+    var T = tiecorrect(ranked);
     if (T === 0) {
         throw new Error("All numbers are identical.");
     }


### PR DESCRIPTION
This seems to be an error.
[See the equivalent code in scipy](https://github.com/scipy/scipy/blob/7c7a5f8393e7b16e5bc81c739c84fe2e639c367f/scipy/stats/stats.py#L7587)